### PR TITLE
Added Quotes for @nfs_path_file in system call

### DIFF
--- a/lib/vagrant-winnfsd/cap/nfs.rb
+++ b/lib/vagrant-winnfsd/cap/nfs.rb
@@ -37,7 +37,7 @@ module VagrantWinNFSd
           gid = env.vagrantfile.config.winnfsd.gid
           uid = env.vagrantfile.config.winnfsd.uid
           logging = env.vagrantfile.config.winnfsd.logging
-          system("#{@nfs_start_command} #{logging} #{@nfs_path_file} #{uid} #{gid}")
+          system("#{@nfs_start_command} #{logging} \"#{@nfs_path_file}\" #{uid} #{gid}")
           sleep 2
         end
       end


### PR DESCRIPTION
This fixes a bug when installing Vagrant on a path like "C:\Program Files (x86)\Vagrant\"
The Quotes prevents the batch file nfsservice.bat from recognizing paths with spaces as multiple args.
