### PR TITLE
Use machine.config to retrieve host_ip

### DIFF
--- a/lib/vagrant-winnfsd/synced_folder.rb
+++ b/lib/vagrant-winnfsd/synced_folder.rb
@@ -73,8 +73,8 @@ module VagrantWinNFSd
       # Allow override of the host IP via config.
       # TODO: This should be configurable somewhere deeper in Vagrant core.
       host_ip = nfsopts[:nfs_host_ip]
-      if (machine.env.vagrantfile.config.winnfsd.host_ip)
-        host_ip = machine.env.vagrantfile.config.winnfsd.host_ip
+      if (machine.config.winnfsd.host_ip)
+        host_ip = machine.config.winnfsd.host_ip
       end
 	  
       # Mount them!


### PR DESCRIPTION
`machine.env.vagrantfile.config.winnfsd.host_ip` doesn't seem to work in a multi-machine environment.