### PR TITLE
Restart WinNFSd on `vagrant reload`

### DIFF
--- a/lib/vagrant-winnfsd/cap/nfs.rb
+++ b/lib/vagrant-winnfsd/cap/nfs.rb
@@ -44,7 +44,7 @@ module VagrantWinNFSd
           system("#{@nfs_start_command} #{logging} \"#{@nfs_path_file}\" #{uid} #{gid}")
           sleep 2
         else
-          @logger.info("WinNFSd is already running and `config.winnfsd.halt_on_reload` is not set; shares will not be changed.")
+          ui.info I18n.t('vagrant_winnfsd.hosts.windows.nfs_already_running')
         end
       end
 

--- a/lib/vagrant-winnfsd/cap/nfs.rb
+++ b/lib/vagrant-winnfsd/cap/nfs.rb
@@ -31,14 +31,18 @@ module VagrantWinNFSd
           f.puts(nfs_file_lines)
         end
 
+        if self.nfs_running? && env.vagrantfile.config.winnfsd.stop_on_reload
+          system("#{@nfs_stop_command}")
+        end
 
-
-        unless self.nfs_running?
+        if !self.nfs_running? || env.vagrantfile.config.winnfsd.stop_on_reload
           gid = env.vagrantfile.config.winnfsd.gid
           uid = env.vagrantfile.config.winnfsd.uid
           logging = env.vagrantfile.config.winnfsd.logging
           system("#{@nfs_start_command} #{logging} \"#{@nfs_path_file}\" #{uid} #{gid}")
           sleep 2
+        else
+          @logger.info("WinNFSd is already running and `config.winnfsd.stop_on_reload` is not set; shares will not be changed.")
         end
       end
 

--- a/lib/vagrant-winnfsd/cap/nfs.rb
+++ b/lib/vagrant-winnfsd/cap/nfs.rb
@@ -31,18 +31,20 @@ module VagrantWinNFSd
           f.puts(nfs_file_lines)
         end
 
-        if self.nfs_running? && env.vagrantfile.config.winnfsd.stop_on_reload
-          system("#{@nfs_stop_command}")
+        is_running = self.nfs_running?
+        
+        if is_running && self.halt_on_reload?(env)
+          self.halt_nfs
         end
 
-        if !self.nfs_running? || env.vagrantfile.config.winnfsd.stop_on_reload
+        if !is_running || self.halt_on_reload?(env)
           gid = env.vagrantfile.config.winnfsd.gid
           uid = env.vagrantfile.config.winnfsd.uid
           logging = env.vagrantfile.config.winnfsd.logging
           system("#{@nfs_start_command} #{logging} \"#{@nfs_path_file}\" #{uid} #{gid}")
           sleep 2
         else
-          @logger.info("WinNFSd is already running and `config.winnfsd.stop_on_reload` is not set; shares will not be changed.")
+          @logger.info("WinNFSd is already running and `config.winnfsd.halt_on_reload` is not set; shares will not be changed.")
         end
       end
 
@@ -80,10 +82,18 @@ module VagrantWinNFSd
 
       protected
 
+      def self.halt_on_reload?(env)
+        env.vagrantfile.config.winnfsd.halt_on_reload == 'on'
+      end
+      
       def self.nfs_running?
         system("#{@nfs_check_command}")
       end
-
+      
+      def self.halt_nfs
+        system("#{@nfs_stop_command}")
+      end
+      
       def self.nfs_cleanup(id)
         return unless File.exist?(@nfs_path_file)
 

--- a/lib/vagrant-winnfsd/config/winnfsd.rb
+++ b/lib/vagrant-winnfsd/config/winnfsd.rb
@@ -33,8 +33,8 @@ module VagrantWinNFSd
         @logging = 'off'         if @logging == UNSET_VALUE
         @uid = 0                 if @uid == UNSET_VALUE
         @gid = 0                 if @gid == UNSET_VALUE
-        @host_ip = ""            if @host_ip == UNSET_VALUE
-        @stop_on_reload = 'off'  if @stop_on_reload == UNSET_VALUE
+        @host_ip = ''            if @host_ip == UNSET_VALUE
+        @halt_on_reload = 'off'  if @halt_on_reload == UNSET_VALUE
       end
     end
   end

--- a/lib/vagrant-winnfsd/config/winnfsd.rb
+++ b/lib/vagrant-winnfsd/config/winnfsd.rb
@@ -7,14 +7,14 @@ module VagrantWinNFSd
       attr_accessor :uid
       attr_accessor :gid
       attr_accessor :host_ip
-      attr_accessor :stop_on_reload
+      attr_accessor :halt_on_reload
 
       def initialize
         @logging        = UNSET_VALUE
         @uid            = UNSET_VALUE
         @gid            = UNSET_VALUE
         @host_ip        = UNSET_VALUE
-        @stop_on_reload = UNSET_VALUE
+        @halt_on_reload = UNSET_VALUE
       end
 
       def validate(machine)
@@ -24,7 +24,7 @@ module VagrantWinNFSd
         errors << 'winnfsd.uid cannot be nil.'                            if machine.config.winnfsd.uid.nil?
         errors << 'winnfsd.gid cannot be nil.'                            if machine.config.winnfsd.gid.nil?
         errors << 'winnfsd.host_ip cannot be nil.'                        if machine.config.winnfsd.host_ip.nil?
-        errors << 'winnfsd.stop_on_reload can only be \'on\' or \'off\'.' unless ['on', 'off'].include?(machine.config.winnfsd.stop_on_reload)
+        errors << 'winnfsd.halt_on_reload can only be \'on\' or \'off\'.' unless ['on', 'off'].include?(machine.config.winnfsd.halt_on_reload)
 
         { "WinNFSd" => errors }
       end

--- a/lib/vagrant-winnfsd/config/winnfsd.rb
+++ b/lib/vagrant-winnfsd/config/winnfsd.rb
@@ -7,30 +7,34 @@ module VagrantWinNFSd
       attr_accessor :uid
       attr_accessor :gid
       attr_accessor :host_ip
+      attr_accessor :stop_on_reload
 
       def initialize
-        @logging = UNSET_VALUE
-        @uid     = UNSET_VALUE
-        @gid     = UNSET_VALUE
-        @host_ip = UNSET_VALUE
+        @logging        = UNSET_VALUE
+        @uid            = UNSET_VALUE
+        @gid            = UNSET_VALUE
+        @host_ip        = UNSET_VALUE
+        @stop_on_reload = UNSET_VALUE
       end
 
       def validate(machine)
         errors = []
 
-        errors << 'winnfsd.logging cannot only be \'on\' or \'off\'.' unless (machine.config.winnfsd.logging == 'on' || machine.config.winnfsd.logging == 'off')
-        errors << 'winnfsd.uid cannot be nil.'                        if machine.config.winnfsd.uid.nil?
-        errors << 'winnfsd.gid cannot be nil.'                        if machine.config.winnfsd.gid.nil?
-        errors << 'winnfsd.host_ip cannot be nil.'                    if machine.config.winnfsd.host_ip.nil?
+        errors << 'winnfsd.logging can only be \'on\' or \'off\'.'        unless ['on', 'off'].include?(machine.config.winnfsd.logging)
+        errors << 'winnfsd.uid cannot be nil.'                            if machine.config.winnfsd.uid.nil?
+        errors << 'winnfsd.gid cannot be nil.'                            if machine.config.winnfsd.gid.nil?
+        errors << 'winnfsd.host_ip cannot be nil.'                        if machine.config.winnfsd.host_ip.nil?
+        errors << 'winnfsd.stop_on_reload can only be \'on\' or \'off\'.' unless ['on', 'off'].include?(machine.config.winnfsd.stop_on_reload)
 
         { "WinNFSd" => errors }
       end
 
       def finalize!
-        @logging = 'off'  if @logging == UNSET_VALUE
-        @uid = 0          if @uid == UNSET_VALUE
-        @gid = 0          if @gid == UNSET_VALUE
-        @host_ip = ""     if @host_ip == UNSET_VALUE
+        @logging = 'off'         if @logging == UNSET_VALUE
+        @uid = 0                 if @uid == UNSET_VALUE
+        @gid = 0                 if @gid == UNSET_VALUE
+        @host_ip = ""            if @host_ip == UNSET_VALUE
+        @stop_on_reload = 'off'  if @stop_on_reload == UNSET_VALUE
       end
     end
   end

--- a/lib/vagrant-winnfsd/synced_folder.rb
+++ b/lib/vagrant-winnfsd/synced_folder.rb
@@ -73,7 +73,7 @@ module VagrantWinNFSd
       # Allow override of the host IP via config.
       # TODO: This should be configurable somewhere deeper in Vagrant core.
       host_ip = nfsopts[:nfs_host_ip]
-      if (machine.env.vagrantfile.config.winnfsd.host_ip)
+      unless machine.env.vagrantfile.config.winnfsd.host_ip.empty?
         host_ip = machine.env.vagrantfile.config.winnfsd.host_ip
       end
 	  

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -7,6 +7,9 @@ en:
           Preparing to edit nfs mounting file.
         nfs_prune: |-
           Pruning invalid NFS exports.
+        nfs_already_running: |-
+          WinNFSd is already running and `config.winnfsd.halt_on_reload` is not set; shares may not match the latest
+          configuration.
     firewall:
       error: |-
         It seems that you don't have the privileges to change the firewall rules. NFS will not work without that firewall


### PR DESCRIPTION
Closes #51.

This also adds a new option `config.winnfsd.halt_on_reload` that can be set to `on` or `off` to toggle this behavior.