### PR TITLE
Use the vagrant home path to store the nfspaths file.

### DIFF
--- a/lib/vagrant-winnfsd/cap/nfs.rb
+++ b/lib/vagrant-winnfsd/cap/nfs.rb
@@ -9,7 +9,7 @@ module VagrantWinNFSd
       @nfs_check_command = "\"#{executable}\" status"
       @nfs_start_command = "\"#{executable}\" start"
       @nfs_stop_command = "\"#{executable}\" halt"
-      @nfs_path_file = "#{Vagrant.source_root}/nfspaths"
+      @nfs_path_file = "#{Vagrant.user_data_path}/nfspaths"
 
       def self.nfs_export(env, ui, id, ips, folders)
         ui.info I18n.t('vagrant_winnfsd.hosts.windows.nfs_export')


### PR DESCRIPTION
I propose to store the `nfspaths` file in the vagrant home path instead the installation directory.
The advantage of this is less permission headaches on windows.
If Vagrant is installed in the "Program Files" folder you might run into issues writing into that folder due UAC oder directory owner ship (TrustedInstaller).
Writing in the vagrant home directory should be possible since by default it's a directory within the Windows user directory - which is writeable by the current user.

This could solve following issues:
* #79
* #73 