### PR TITLE
Improve error handling upon startup failure

### DIFF
--- a/bin/nfsservice.bat
+++ b/bin/nfsservice.bat
@@ -30,7 +30,7 @@ if %1==start (
     ) else (
         start "" "%~dp0winnfsd" -log %2 -pathFile %3 -id %4 %5
         
-        ping 127.0.0.1 -n 3 > nul
+        %windir%\system32\timeout.exe /t 3 > nul 2> nul & if errorlevel 1 ping 127.0.0.1 -n 3
         %windir%\system32\tasklist.exe /nh /fi "imagename eq winnfsd.exe" | %windir%\system32\find.exe /I /N "winnfsd.exe" > nul
         
         if errorlevel 1 (

--- a/bin/nfsservice.bat
+++ b/bin/nfsservice.bat
@@ -29,7 +29,16 @@ if %1==start (
         echo already running
     ) else (
         start "" "%~dp0winnfsd" -log %2 -pathFile %3 -id %4 %5
-        echo started
+        
+        ping 127.0.0.1 -n 3 > nul
+        %windir%\system32\tasklist.exe /nh /fi "imagename eq winnfsd.exe" | %windir%\system32\find.exe /I /N "winnfsd.exe" > nul
+        
+        if errorlevel 1 (
+            echo failed to start; ensure that ports 111 and 2049 are not already in use
+            exit 1
+        ) else (
+            echo started
+        )
     )
     
     exit 0


### PR DESCRIPTION
When `winnfsd.exe`  fails to start for any reason, `nfsservice.bat` echoes `started`, and steams on ahead, with no indication that a failure occurred.

For example, if the port bindings cannot be made, because the ports are already in use, `winnfsd.exe` will fail to start, and Vagrant will complain only once the `mount ...` command fails over SSH.

This slight modification at least gives the user a hint as to what may be wrong.

Given that `winnfsd.exe` does not return a non-zero exit code if it fails to start, we have little choice but to check to see if it is running after we attempt to start it. (This logic would be a lot simpler if the `winnfsd.exe` could be made to return proper exit codes on failure.)

It is necessary to pause/sleep briefly after the attempt to start `winnfsd.exe`, because it may take a second or two for the program to exit on failure. While a bit "hacky", the `ping 127.0.0.1 -n 3 > nul` command works well and is available on all relevant versions of Windows. (The `timeout` command is absent from Windows XP, which while end-of-life, makes it a less favorable choice.)

Finally, I've prefixed the various executable paths with `%windir%\system32`, which eliminates potential conflicts with Cygwin or Git executables, for example (`find`, in particular), as many Vagrant users have one or both installed.

As I said, it would be far more ideal to modify `winnfsd.exe` to issue proper return codes in various failures states, but this is an improvement that can be made in the meantime.

Thanks for considering!

P.S. I can't seem to eliminate that newline change at the end of the file; GitHub seems to be doing that on its own.