### PR TITLE
Remove $PS1 from install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Supported guests:
 ## Installation
 
 ```
-$ vagrant plugin install vagrant-winnfsd
+vagrant plugin install vagrant-winnfsd
 ```
 
 ## Activate NFS for Vagrant


### PR DESCRIPTION
It irritates me that I cannot simply use the provided copy button because $PS1 is included.

Now users (okay me) can just copy the install command and use it as is.